### PR TITLE
Gl-DB: Computers

### DIFF
--- a/app/models/computer.rb
+++ b/app/models/computer.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Computer < ApplicationRecord
+  belongs_to :user, optional: true
+
+  validates :name, presence: true
+
+  before_create :generate_uuid
+
+  private
+
+  def generate_uuid
+    self.uuid ||= SecureRandom.uuid
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
+  has_many :computers, dependent: :destroy
+
   validates :email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }
 end

--- a/db/migrate/20210529105216_create_computers.rb
+++ b/db/migrate/20210529105216_create_computers.rb
@@ -1,0 +1,10 @@
+class CreateComputers < ActiveRecord::Migration[6.1]
+  def change
+    create_table :computers do |t|
+      t.string :name, null: false, default: ''
+      t.uuid :uuid, null: false, unique: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210529105849_add_user_to_computers.rb
+++ b/db/migrate/20210529105849_add_user_to_computers.rb
@@ -1,0 +1,5 @@
+class AddUserToComputers < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :computers, :user, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_28_143610) do
+ActiveRecord::Schema.define(version: 2021_05_29_105849) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "computers", force: :cascade do |t|
+    t.string "name", default: "", null: false
+    t.uuid "uuid", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_computers_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "first_name"
@@ -23,4 +32,5 @@ ActiveRecord::Schema.define(version: 2021_05_28_143610) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  add_foreign_key "computers", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,6 @@
 # frozen_string_literal: true
 
 50.times { User.find_or_create_by(email: Faker::Internet.email) }
+User.all.each do |user|
+  user.computers = [FactoryBot.create(:computer)]
+end

--- a/spec/factories/computers.rb
+++ b/spec/factories/computers.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :computer do
+    name { Faker::Name.name }
+  end
+end

--- a/spec/models/computer_spec.rb
+++ b/spec/models/computer_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Computer, type: :model do
+  describe 'relations' do
+    it { is_expected.to belong_to(:user).optional(true) }
+  end
+
+  describe 'validation' do
+    it { is_expected.to validate_presence_of(:name) }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,6 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
+  describe 'relations' do
+    it { is_expected.to have_many(:computers) }
+  end
+
   describe 'validation' do
     it { is_expected.to validate_presence_of(:email) }
   end


### PR DESCRIPTION
Add computers to DB with validation presence of name, Add generator for UUID after create computer. Also add optional relation between user and computers. Update seeds to create computers for each user, update and add spec for both model.